### PR TITLE
Remove legacy helpers and add kicker actions 

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
 
       - name: Show Forge version
         run: |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Below is an outline of all functions used in the library.
 - `reg()`: Ilk Registry
 - `spotter()`: Oracle Liason
 - `flap()`: Surplus Auction Module
-- `kicker()`: Surplus Processing Trigger
+- `kicker()`: Kicker surplus-processing trigger
 - `flop()`: Debt Auction Module
 - `osmMom()`: OSM Circuit Breaker
 - `clipperMom()`: Clipper Governance Interface (Liquidations 2.0)
@@ -144,8 +144,8 @@ Below is an outline of all functions used in the library.
 - `decreaseGlobalDebtCeiling(uint256 _amount)`: Decrease the global debt ceiling.
 - `setDSR(uint256 _rate, bool _doDrip)`: Set the Dai Savings Rate.
 - `setSSR(uint256 _rate, bool _doDrip)`: Set the Sky Savings Rate.
-- `setKickerAuctionAmount(uint256 _amount)`: Set the fixed Kicker surplus-processing lot in whole USDS units, converted to RAD.
-- `setKickerSurplusBuffer(int256 _amount)`: Set the signed Kicker surplus-processing threshold in whole USDS units, converted to RAD. A negative value lowers the execution threshold.
+- `setKickerAuctionAmount(uint256 _amount)`: Set `Kicker.kbump`, its fixed lot size, from whole USDS units converted to RAD.
+- `setKickerSurplusBuffer(int256 _amount)`: Set `Kicker.khump`, its signed flap threshold, from whole USDS units converted to RAD. A negative value lowers the net surplus required for `Kicker.flap()`.
 - `setSurplusAuctionMinPriceThreshold(uint256 _pct_bps)`: Set the relative multiplier of the reference price to insist in the swap. For example, `98_00` bps allows a 2% drop in the reference price.
 - `setDebtAuctionDelay(uint256 _length)`: Set the number of seconds that pass before system debt is auctioned for MKR tokens.
 - `setDebtAuctionDebtAmount(uint256 _amount)`: Set the debt amount for system debt to be covered by each debt auction.

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Below is an outline of all functions used in the library.
 - `reg()`: Ilk Registry
 - `spotter()`: Oracle Liason
 - `flap()`: Surplus Auction Module
+- `kicker()`: Surplus Processing Trigger
 - `flop()`: Debt Auction Module
 - `osmMom()`: OSM Circuit Breaker
-- `govGuard()`: SKY Authority
 - `clipperMom()`: Clipper Governance Interface (Liquidations 2.0)
 - `pauseProxy()`: Governance Authority
 - `autoLine()`: Debt Ceiling Auto Adjustment
@@ -93,7 +93,6 @@ Below is an outline of all functions used in the library.
 - `usdsJoin()`: Join adapter for USDS
 - `lerpFab()`: Lerp Factory Contract
 - `pause()`: Pause Contract
-- `flip(bytes32 _ilk)`: Collateral Auction Module (per ilk)
 - `clip(bytes32 _ilk)`: Collateral Auction Module (per ilk)
 - `calc(bytes32 _ilk)`: Pricing Function for Liquidation (per ilk)
 
@@ -145,9 +144,9 @@ Below is an outline of all functions used in the library.
 - `decreaseGlobalDebtCeiling(uint256 _amount)`: Decrease the global debt ceiling.
 - `setDSR(uint256 _rate, bool _doDrip)`: Set the Dai Savings Rate.
 - `setSSR(uint256 _rate, bool _doDrip)`: Set the Sky Savings Rate.
-- `setSurplusAuctionAmount(uint256 _amount)`: Set the amount for system surplus auctions.
+- `setKickerAuctionAmount(uint256 _amount)`: Set the fixed Kicker surplus-processing lot in whole USDS units, converted to RAD.
+- `setKickerSurplusBuffer(int256 _amount)`: Set the signed Kicker surplus-processing threshold in whole USDS units, converted to RAD. A negative value lowers the execution threshold.
 - `setSurplusAuctionMinPriceThreshold(uint256 _pct_bps)`: Set the relative multiplier of the reference price to insist in the swap. For example, `98_00` bps allows a 2% drop in the reference price.
-- `setSurplusBuffer(uint256 _amount)`: Set the amount for system surplus buffer, must be exceeded before surplus auctions start.
 - `setDebtAuctionDelay(uint256 _length)`: Set the number of seconds that pass before system debt is auctioned for MKR tokens.
 - `setDebtAuctionDebtAmount(uint256 _amount)`: Set the debt amount for system debt to be covered by each debt auction.
 - `setDebtAuctionGovAmount(uint256 _amount)`: Set the starting governance token amount to be auctioned off to cover system debt in debt auctions.
@@ -195,10 +194,6 @@ Below is an outline of all functions used in the library.
 ### Governance Security Module
 
 - `setGSMDelay`: Sets the GSM delay for governance actions.
-
-### Direct Deposit Module
-
-- `setDDMTargetInterestRate(address _ddm, uint256 _pct_bps)`: Set the target rate (`bar`) for a DDM module.
 
 ### Collateral Onboarding
 

--- a/src/DssAction.t.sol
+++ b/src/DssAction.t.sol
@@ -614,7 +614,7 @@ contract DssActionTest is Test {
         assertEq(kicker.khump(), initialKhump); // unchanged
     }
 
-    function test_setKickerAuctionAmountMax() public {
+    function test_setKickerAuctionAmountPrecisionBoundary() public {
         action.setKickerAuctionAmount_test(WAD - 1);
         assertEq(kicker.kbump(), (WAD - 1) * RAD);
     }

--- a/src/DssAction.t.sol
+++ b/src/DssAction.t.sol
@@ -76,9 +76,9 @@ interface Univ2OracleFactoryLike {
     function build(address, address, bytes32, address, address) external returns (address oracle);
 }
 
-interface DDMLike {
-    function bar() external view returns (uint256);
-    function rely(address) external;
+interface KickerLike {
+    function kbump() external view returns (uint256);
+    function khump() external view returns (int256);
 }
 
 interface FlapUniV2Like {
@@ -122,6 +122,7 @@ contract DssActionTest is Test {
     UsdsJoinLike usdsJoin;
     SpotAbstract spot;
     FlapUniV2Like flap;
+    KickerLike kicker;
     FlopAbstract flop;
     DSTokenAbstract gov;
     DSTokenAbstract mkr;
@@ -176,6 +177,7 @@ contract DssActionTest is Test {
         usdsToken = UsdsLike(LOG.getAddress("USDS"));
         spot = SpotAbstract(LOG.getAddress("MCD_SPOT"));
         flap = FlapUniV2Like(LOG.getAddress("MCD_FLAP"));
+        kicker = KickerLike(LOG.getAddress("MCD_KICK"));
         flop = FlopAbstract(LOG.getAddress("MCD_FLOP"));
         gov = DSTokenAbstract(LOG.getAddress("MCD_GOV"));
         mkr = DSTokenAbstract(LOG.getAddress("MKR"));
@@ -201,6 +203,7 @@ contract DssActionTest is Test {
         vm.label(address(usdsJoin), "USDS_JOIN");
         vm.label(address(spot), "SPOT");
         vm.label(address(flap), "FLAP");
+        vm.label(address(kicker), "KICKER");
         vm.label(address(flop), "FLOP");
         vm.label(address(gov), "GOV");
         vm.label(address(mkr), "MKR");
@@ -228,6 +231,7 @@ contract DssActionTest is Test {
         giveAuth(address(jug), address(this));
         giveAuth(address(jug), address(action));
         giveAuth(address(flap), address(action));
+        giveAuth(address(kicker), address(action));
         giveAuth(address(flop), address(action));
         giveAuth(address(daiJoin), address(action));
         giveAuth(address(LOG), address(action));
@@ -592,14 +596,84 @@ contract DssActionTest is Test {
         assertEq(pot.dsr(), rate);
     }
 
-    function test_setSurplusAuctionAmount() public {
-        action.setSurplusAuctionAmount_test(100 * THOUSAND);
-        assertEq(vow.bump(), 100 * THOUSAND * RAD);
+    function test_kicker() public view {
+        assertEq(action.kicker_test(), address(kicker));
+        assertGt(address(kicker).code.length, 0);
     }
 
-    function test_setSurplusBuffer() public {
-        action.setSurplusBuffer_test(1 * MILLION);
-        assertEq(vow.hump(), 1 * MILLION * RAD);
+    function test_setKickerAuctionAmount() public {
+        uint256 amount = 7_000;
+        uint256 initialKbump = kicker.kbump();
+        int256 initialKhump = kicker.khump();
+
+        assertNotEq(initialKbump, amount * RAD, "Precondition: target kbump must differ");
+
+        action.setKickerAuctionAmount_test(amount);
+
+        assertEq(kicker.kbump(), amount * RAD);
+        assertEq(kicker.khump(), initialKhump); // unchanged
+    }
+
+    function test_setKickerAuctionAmountMax() public {
+        action.setKickerAuctionAmount_test(WAD - 1);
+        assertEq(kicker.kbump(), (WAD - 1) * RAD);
+    }
+
+    function test_setKickerAuctionAmountReverts() public {
+        uint256 initialKbump = kicker.kbump();
+
+        vm.expectRevert();
+        action.setKickerAuctionAmount_test(WAD);
+
+        assertEq(kicker.kbump(), initialKbump);
+    }
+
+    function test_setKickerSurplusBufferNegative() public {
+        int256 amount = -100 * int256(MILLION);
+        uint256 initialKbump = kicker.kbump();
+        int256 initialKhump = kicker.khump();
+
+        assertNotEq(initialKhump, amount * int256(RAD), "Precondition: target khump must differ");
+
+        action.setKickerSurplusBuffer_test(amount);
+
+        assertEq(kicker.khump(), amount * int256(RAD));
+        assertEq(kicker.kbump(), initialKbump); // unchanged
+    }
+
+    function test_setKickerSurplusBufferZero() public {
+        action.setKickerSurplusBuffer_test(0);
+        assertEq(kicker.khump(), 0);
+    }
+
+    function test_setKickerSurplusBufferPositive() public {
+        int256 amount = 100 * int256(MILLION);
+
+        action.setKickerSurplusBuffer_test(amount);
+        assertEq(kicker.khump(), amount * int256(RAD));
+    }
+
+    function test_setKickerSurplusBufferBounds() public {
+        int256 lowerBound = -int256(WAD) + 1;
+        int256 upperBound = int256(WAD) - 1;
+
+        action.setKickerSurplusBuffer_test(lowerBound);
+        assertEq(kicker.khump(), lowerBound * int256(RAD));
+
+        action.setKickerSurplusBuffer_test(upperBound);
+        assertEq(kicker.khump(), upperBound * int256(RAD));
+    }
+
+    function test_setKickerSurplusBufferReverts() public {
+        int256 initialKhump = kicker.khump();
+
+        vm.expectRevert();
+        action.setKickerSurplusBuffer_test(-int256(WAD));
+        assertEq(kicker.khump(), initialKhump);
+
+        vm.expectRevert();
+        action.setKickerSurplusBuffer_test(int256(WAD));
+        assertEq(kicker.khump(), initialKhump);
     }
 
     function test_setSurplusAuctionMinPriceThreshold() public {
@@ -948,20 +1022,6 @@ contract DssActionTest is Test {
         // Reverts if the value is lower than 12 hours
         vm.expectRevert();
         pauseProxy.exec(address(action), abi.encodeCall(action.setGSMDelay_test, 8 hours));
-    }
-
-    function test_setDDMTargetInterestRate() public {
-        DDMLike ddm = DDMLike(LOG.getAddress("DIRECT_AAVEV2_DAI_PLAN"));
-        giveAuth(address(ddm), address(action));
-
-        action.setDDMTargetInterestRate_test(address(ddm), 500); // set to 5%
-        assertEq(ddm.bar(), 5 * RAY / 100);
-
-        action.setDDMTargetInterestRate_test(address(ddm), 0); // set to 0%
-        assertEq(ddm.bar(), 0);
-
-        action.setDDMTargetInterestRate_test(address(ddm), 1000); // set to 10%
-        assertEq(ddm.bar(), 10 * RAY / 100);
     }
 
     function test_collateralOnboardingBase() public {

--- a/src/DssExecLib.sol
+++ b/src/DssExecLib.sol
@@ -37,6 +37,7 @@ interface Kissable {
 interface Fileable {
     function file(bytes32, address) external;
     function file(bytes32, uint256) external;
+    function file(bytes32, int256) external;
     function file(bytes32, bytes32, uint256) external;
     function file(bytes32, bytes32, address) external;
 }
@@ -286,6 +287,12 @@ library DssExecLib {
         return getChangelogAddress("MCD_FLAP");
     }
 
+    /// @notice Get the KICK (surplus processing trigger) contract address from the changelog
+    /// @return The address of the KICK contract
+    function kicker() public view returns (address) {
+        return getChangelogAddress("MCD_KICK");
+    }
+
     /// @notice Get the FLOP (debt auction) contract address from the changelog
     /// @return The address of the FLOP contract
     function flop() public view returns (address) {
@@ -296,12 +303,6 @@ library DssExecLib {
     /// @return The address of the OSM_MOM contract
     function osmMom() public view returns (address) {
         return getChangelogAddress("OSM_MOM");
-    }
-
-    /// @notice Get the GOV_GUARD (governance guard) contract address from the changelog
-    /// @return The address of the GOV_GUARD contract
-    function govGuard() public view returns (address) {
-        return getChangelogAddress("GOV_GUARD");
     }
 
     /// @notice Get the CLIPPER_MOM (liquidation circuit breaker) contract address from the changelog
@@ -351,13 +352,6 @@ library DssExecLib {
     /// @return _clip The address of the liquidation contract for the given ilk
     function clip(bytes32 _ilk) public view returns (address _clip) {
         _clip = RegistryLike(reg()).xlip(_ilk);
-    }
-
-    /// @notice Get the collateral auction contract address for a given ilk (legacy)
-    /// @param _ilk The collateral type identifier
-    /// @return _flip The address of the auction contract for the given ilk
-    function flip(bytes32 _ilk) public view returns (address _flip) {
-        _flip = RegistryLike(reg()).xlip(_ilk);
     }
 
     /// @notice Get the pricing calculator contract address for a given ilk
@@ -611,18 +605,18 @@ library DssExecLib {
         setValue(susds(), "ssr", _rate);
     }
 
-    /// @dev Set the amount for system surplus auctions. Amount will be converted to the correct internal precision.
-    /// @param _amount The amount to set (ex. 10m amount == 10000000)
-    function setSurplusAuctionAmount(uint256 _amount) public {
-        require(_amount < WAD); // "LibDssExec/incorrect-vow-bump-precision"
-        setValue(vow(), "bump", _amount * RAD);
+    /// @dev Set the fixed surplus-processing lot for Kicker. Amount will be converted to RAD.
+    /// @param _amount The amount in whole USDS units (ex. 10m amount == 10000000)
+    function setKickerAuctionAmount(uint256 _amount) public {
+        require(_amount < WAD); // "LibDssExec/incorrect-kick-kbump-precision"
+        Fileable(kicker()).file("kbump", _amount * RAD);
     }
 
-    /// @dev Set the amount for system surplus buffer, must be exceeded before surplus auctions start. Amount will be converted to the correct internal precision.
-    /// @param _amount The amount to set (ex. 10m amount == 10000000)
-    function setSurplusBuffer(uint256 _amount) public {
-        require(_amount < WAD); // "LibDssExec/incorrect-vow-hump-precision"
-        setValue(vow(), "hump", _amount * RAD);
+    /// @dev Set the signed surplus-processing threshold for Kicker. Amount will be converted to RAD.
+    /// @param _amount The threshold in whole USDS units. A negative value lowers the execution threshold.
+    function setKickerSurplusBuffer(int256 _amount) public {
+        require(-int256(WAD) < _amount && _amount < int256(WAD)); // "LibDssExec/incorrect-kick-khump-precision"
+        Fileable(kicker()).file("khump", _amount * int256(RAD));
     }
 
     /// @dev Set the minimum price threshold for surplus auctions. Amount will be converted to the correct internal precision.
@@ -972,17 +966,6 @@ library DssExecLib {
     function setGSMDelay(uint256 _delay) public {
         require(_delay >= 12 hours); // DssExecLib/delay-too-low
         PauseLike(pause()).setDelay(_delay);
-    }
-
-    /* ----- Direct Deposit Module ----- */
-
-    /// @dev Sets the target rate threshold for a direct deposit module (ddm)
-    /// @dev Aave: Targets the variable borrow rate
-    /// @param _ddm The address of the DDM contract
-    /// @param _pct_bps Target rate in basis points. (ex. 4% == 400)
-    function setDDMTargetInterestRate(address _ddm, uint256 _pct_bps) public {
-        require(_pct_bps < BPS_ONE_HUNDRED_PCT); // DssExecLib/bar-too-high
-        setValue(_ddm, "bar", rdiv(_pct_bps, BPS_ONE_HUNDRED_PCT));
     }
 
     /* ----- Collateral Onboarding ----- */

--- a/src/DssExecLib.sol
+++ b/src/DssExecLib.sol
@@ -287,8 +287,8 @@ library DssExecLib {
         return getChangelogAddress("MCD_FLAP");
     }
 
-    /// @notice Get the KICK (surplus processing trigger) contract address from the changelog
-    /// @return The address of the KICK contract
+    /// @notice Get the Kicker (MCD_KICK) contract address from the changelog
+    /// @return The address of the Kicker contract
     function kicker() public view returns (address) {
         return getChangelogAddress("MCD_KICK");
     }
@@ -605,15 +605,15 @@ library DssExecLib {
         setValue(susds(), "ssr", _rate);
     }
 
-    /// @dev Set the fixed surplus-processing lot for Kicker. Amount will be converted to RAD.
-    /// @param _amount The amount in whole USDS units (ex. 10m amount == 10000000)
+    /// @dev Set Kicker.kbump, the fixed lot size used by Kicker.flap(). The amount is provided in whole USDS units and converted to RAD.
+    /// @param _amount The fixed lot size in whole USDS units (ex. 10m USDS == 10000000)
     function setKickerAuctionAmount(uint256 _amount) public {
         require(_amount < WAD); // "LibDssExec/incorrect-kick-kbump-precision"
         Fileable(kicker()).file("kbump", _amount * RAD);
     }
 
-    /// @dev Set the signed surplus-processing threshold for Kicker. Amount will be converted to RAD.
-    /// @param _amount The threshold in whole USDS units. A negative value lowers the execution threshold.
+    /// @dev Set Kicker.khump, the signed flap threshold. The amount is provided in whole USDS units and converted to RAD while preserving its sign.
+    /// @param _amount The signed flap threshold in whole USDS units. A negative value lowers the net surplus required for Kicker.flap().
     function setKickerSurplusBuffer(int256 _amount) public {
         require(-int256(WAD) < _amount && _amount < int256(WAD)); // "LibDssExec/incorrect-kick-khump-precision"
         Fileable(kicker()).file("khump", _amount * int256(RAD));

--- a/src/DssExecLib.sol
+++ b/src/DssExecLib.sol
@@ -606,6 +606,7 @@ library DssExecLib {
     }
 
     /// @dev Set Kicker.kbump, the fixed lot size used by Kicker.flap(). The amount is provided in whole USDS units and converted to RAD.
+    /// @dev The WAD bound only validates input precision and RAD conversion; callers must ensure kbump * burn does not overflow in Splitter.kick().
     /// @param _amount The fixed lot size in whole USDS units (ex. 10m USDS == 10000000)
     function setKickerAuctionAmount(uint256 _amount) public {
         require(_amount < WAD); // "LibDssExec/incorrect-kick-kbump-precision"

--- a/src/mocks/MockDssSpellAction.sol
+++ b/src/mocks/MockDssSpellAction.sol
@@ -136,12 +136,16 @@ contract MockDssSpellAction is DssAction {
         DssExecLib.setSSR(rate, true);
     }
 
-    function setSurplusAuctionAmount_test(uint256 amount) public {
-        DssExecLib.setSurplusAuctionAmount(amount);
+    function kicker_test() public view returns (address) {
+        return DssExecLib.kicker();
     }
 
-    function setSurplusBuffer_test(uint256 amount) public {
-        DssExecLib.setSurplusBuffer(amount);
+    function setKickerAuctionAmount_test(uint256 amount) public {
+        DssExecLib.setKickerAuctionAmount(amount);
+    }
+
+    function setKickerSurplusBuffer_test(int256 amount) public {
+        DssExecLib.setKickerSurplusBuffer(amount);
     }
 
     function setSurplusAuctionMinPriceThreshold_test(uint256 _pct_bps) public {
@@ -294,10 +298,6 @@ contract MockDssSpellAction is DssAction {
 
     function setGSMDelay_test(uint256 _delay) public {
         DssExecLib.setGSMDelay(_delay);
-    }
-
-    function setDDMTargetInterestRate_test(address ddm, uint256 pct_bps) public {
-        DssExecLib.setDDMTargetInterestRate(ddm, pct_bps);
     }
 
     function addCollateralBase_test(bytes32 ilk, address gem, address join, address clip, address calc, address pip)


### PR DESCRIPTION
This PR aligns `DssExecLib` with the active Kicker-based surplus-processing architecture and removes helpers for legacy or operationally inactive paths:

- Adding `kicker()` to resolve `MCD_KICK` and extending the internal `Fileable` interface with signed parameter support
- Replacing the obsolete Vow `bump` and `hump` helpers with `setKickerAuctionAmount` and `setKickerSurplusBuffer`, converting whole USDS inputs to `RAD` and preserving signed `khump` values
- Removing `govGuard()`, the legacy `flip(bytes32)` alias, and the operationally inactive DDM target-rate helper
- Expanding tests for Kicker address resolution, unit conversion, negative, zero, and positive thresholds, boundary rejection, state preservation, and parameter isolation
- Updating the NatSpec and README documentation 